### PR TITLE
test for array#shuffle fisher-yates implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "devDependencies": {
     "amen": "^1.0.0",
     "coffee-script": "^1.10.0",
-    "json": "^9.0.3"
+    "json": "^9.0.3",
+    "sinon": "^1.17.4"
   },
   "dependencies": {
     "base64-words": "^0.1.1",

--- a/test/array.coffee
+++ b/test/array.coffee
@@ -1,5 +1,6 @@
 assert = require "assert"
 Amen = require "amen"
+sinon = require "sinon"
 
 Amen.describe "Array functions", (context) ->
 
@@ -91,7 +92,17 @@ Amen.describe "Array functions", (context) ->
     assert.deepEqual (remove bx, 3), [2,4]
 
   context.test "shuffle", ->
-    assert.notDeepEqual (shuffle [1..10]), [1..10]
+    # use a sinon sandbox b/c we're mocking globals
+    sinon.test ->
+      # stubbing Math.random() allows us to determine the algorithm used
+      # by expecting a specific result
+      sinon.stub(Math, "random").returns 0.8
+      # "Given Math.random() always returns 0.8..."
+      # * if the biased j = (i * array.size) algorithm is used,
+      #   the expected result is: [ 9, 1, 2, 3, 4, 5, 6, 7, 10, 8 ]
+      # * if the fisher-yates algorithm used, the expected result is:
+      fisher_yates = [ 1, 2, 3, 4, 10, 5, 6, 7, 8, 9 ]
+      assert.deepEqual (shuffle [1..10]), fisher_yates
 
   context.test "range", ->
     assert.deepEqual (range 1, 5), [1, 2, 3, 4, 5]


### PR DESCRIPTION
See the inline code comments re: "how does this test prove the Fisher-Yates algorithm is used"?

I tried to avoid adding `sinon` (to dev dependencies), but I don't know of a better way to selectively mock `Math.random()`.