### PR TITLE
Add CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ node_js:
   - "node"
   - "6"
   - "5"
-  - "4"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "5"
+  - "4"
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/pandastrike/fairmont-helpers.svg)](https://travis-ci.org/pandastrike/fairmont-helpers)
+
 # Fairmont-Helpers
 
 Fairmont-Helpers is a JavaScript library providing a variety of helper functions for dealing with everything from Arrays to Promises in a functional style.


### PR DESCRIPTION
Solves #18 

Do we need to run the tests against any other version of Node? Right now I have it running against the latest stable version, latest v6, and latest v5. The only bummer about doing that is it makes CI take a little longer. Since this is OSS my suggestion is we leave it and just deal with longer test cycles. Other opinions?

I currently have email notifications turned off, but would eventually like to create a `#panda-ci` channel in IRC and have it post updates there. (SEE: https://docs.travis-ci.com/user/notifications/#IRC-notification)