### PR TITLE
Add Polyfill for Buffer.alloc (blurb9-107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fairmont-helpers",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Functional and reactive programming for JavaScript.",
   "files": [
     "src/",

--- a/src/hash.coffee
+++ b/src/hash.coffee
@@ -38,7 +38,7 @@ randomBytes = unless process.platform == "win32"
   (n) ->
     promise (resolve, reject) ->
       fs.open "/dev/urandom", "r", (error, fd) ->
-        buffer = Buffer.alloc n
+        buffer = if Buffer.alloc then Buffer.alloc n else new Buffer n
         fs.read fd, buffer, 0, n, 0, (error, m) ->
           if n == m
             resolve buffer


### PR DESCRIPTION
Added polyfill for Node 4.3 (AWS Lambda) lack of Buffer.alloc method.

Fixes https://github.com/pandastrike/blurb9/issues/107

### How to Test
```
nvm install 4.3
npm test hash  # Tests randomBytes and randomWords specifically
npm test       # Full test
```